### PR TITLE
Feature/#28 프로필 사진 조회 시 바이트배열 대신 사진 조회 API를 반환하게끔 변경

### DIFF
--- a/src/main/java/org/example/sqi_images/auth/authentication/interceptor/AuthenticationInterceptor.java
+++ b/src/main/java/org/example/sqi_images/auth/authentication/interceptor/AuthenticationInterceptor.java
@@ -8,7 +8,7 @@ import org.example.sqi_images.auth.authentication.AuthenticationContext;
 import org.example.sqi_images.auth.authentication.AuthenticationExtractor;
 import org.example.sqi_images.common.exception.NotFoundException;
 import org.example.sqi_images.employee.domain.Employee;
-import org.example.sqi_images.employee.repository.EmployeeRepository;
+import org.example.sqi_images.employee.domain.repository.EmployeeRepository;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
 

--- a/src/main/java/org/example/sqi_images/auth/service/AuthService.java
+++ b/src/main/java/org/example/sqi_images/auth/service/AuthService.java
@@ -10,7 +10,7 @@ import org.example.sqi_images.common.exception.NotFoundException;
 import org.example.sqi_images.common.exception.UnauthorizedException;
 import org.example.sqi_images.employee.domain.Employee;
 import org.example.sqi_images.auth.dto.request.RegisterDto;
-import org.example.sqi_images.employee.repository.EmployeeRepository;
+import org.example.sqi_images.employee.domain.repository.EmployeeRepository;
 import org.springframework.stereotype.Service;
 
 import static org.example.sqi_images.common.constant.Constants.SQISOFT_EMAIL;

--- a/src/main/java/org/example/sqi_images/common/aop/DepartmentMemberAspect.java
+++ b/src/main/java/org/example/sqi_images/common/aop/DepartmentMemberAspect.java
@@ -7,7 +7,7 @@ import org.example.sqi_images.auth.authentication.AuthenticationContext;
 import org.example.sqi_images.auth.authentication.annotation.DepartmentMember;
 import org.example.sqi_images.common.exception.ForbiddenException;
 import org.example.sqi_images.common.exception.NotFoundException;
-import org.example.sqi_images.department.repository.DepartmentRepository;
+import org.example.sqi_images.department.domain.repository.DepartmentRepository;
 import org.example.sqi_images.drive.department.domain.DepartmentFile;
 import org.example.sqi_images.drive.department.domain.repository.DepartmentFileRepository;
 import org.example.sqi_images.employee.domain.Employee;

--- a/src/main/java/org/example/sqi_images/common/aop/DepartmentMemberAspect.java
+++ b/src/main/java/org/example/sqi_images/common/aop/DepartmentMemberAspect.java
@@ -4,7 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Before;
 import org.example.sqi_images.auth.authentication.AuthenticationContext;
-import org.example.sqi_images.auth.authentication.annotation.DepartmentMember;
+import org.example.sqi_images.common.aop.annotation.DepartmentMember;
 import org.example.sqi_images.common.exception.ForbiddenException;
 import org.example.sqi_images.common.exception.NotFoundException;
 import org.example.sqi_images.department.domain.repository.DepartmentRepository;

--- a/src/main/java/org/example/sqi_images/common/aop/annotation/DepartmentMember.java
+++ b/src/main/java/org/example/sqi_images/common/aop/annotation/DepartmentMember.java
@@ -1,4 +1,4 @@
-package org.example.sqi_images.auth.authentication.annotation;
+package org.example.sqi_images.common.aop.annotation;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;

--- a/src/main/java/org/example/sqi_images/common/exception/type/ErrorType.java
+++ b/src/main/java/org/example/sqi_images/common/exception/type/ErrorType.java
@@ -25,7 +25,7 @@ public enum ErrorType {
     NO_RESOURCE_ERROR(40400, "해당 리소스를 찾을 수 없습니다."),
     EMPLOYEE_NOT_FOUND_ERROR(40401, "해당 사원을 찾을 수 없습니다."),
     PROFILE_NOT_FOUND_ERROR(40402, "해당 프로필을 찾을 수 없습니다."),
-    IMAGE_NOT_FOUND_ERROR(40403, "해당 이미지를 찾을 수 없습니다."),
+    PHOTO_NOT_FOUND_ERROR(40403, "해당 이미지를 찾을 수 없습니다."),
     FILE_NOT_FOUND_ERROR(40404, "해당 파일을 찾을 수 없습니다."),
     DEPARTMENT_NOT_FOUND_ERROR(40405,"해당 부서를 찾을 수 없습니다."),
 

--- a/src/main/java/org/example/sqi_images/department/domain/repository/DepartmentRepository.java
+++ b/src/main/java/org/example/sqi_images/department/domain/repository/DepartmentRepository.java
@@ -1,4 +1,4 @@
-package org.example.sqi_images.department.repository;
+package org.example.sqi_images.department.domain.repository;
 
 import org.example.sqi_images.common.domain.DepartmentType;
 import org.example.sqi_images.department.domain.Department;

--- a/src/main/java/org/example/sqi_images/drive/department/controller/DepartmentFileController.java
+++ b/src/main/java/org/example/sqi_images/drive/department/controller/DepartmentFileController.java
@@ -2,7 +2,7 @@ package org.example.sqi_images.drive.department.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.example.sqi_images.auth.authentication.annotation.AuthEmployee;
-import org.example.sqi_images.auth.authentication.annotation.DepartmentMember;
+import org.example.sqi_images.common.aop.annotation.DepartmentMember;
 import org.example.sqi_images.common.dto.page.request.PageRequestDto;
 import org.example.sqi_images.common.dto.page.response.PageResultDto;
 import org.example.sqi_images.drive.common.dto.request.FileInfoUploadDto;

--- a/src/main/java/org/example/sqi_images/drive/department/service/DepartmentFileService.java
+++ b/src/main/java/org/example/sqi_images/drive/department/service/DepartmentFileService.java
@@ -6,7 +6,7 @@ import org.example.sqi_images.common.dto.page.response.PageResultDto;
 import org.example.sqi_images.common.exception.NotFoundException;
 import org.example.sqi_images.common.exception.type.ErrorType;
 import org.example.sqi_images.department.domain.Department;
-import org.example.sqi_images.department.repository.DepartmentRepository;
+import org.example.sqi_images.department.domain.repository.DepartmentRepository;
 import org.example.sqi_images.drive.common.dto.request.FileInfoUploadDto;
 import org.example.sqi_images.drive.common.dto.response.FileDownloadDto;
 import org.example.sqi_images.drive.common.dto.response.FileListDto;

--- a/src/main/java/org/example/sqi_images/drive/global/service/GlobalFileService.java
+++ b/src/main/java/org/example/sqi_images/drive/global/service/GlobalFileService.java
@@ -6,7 +6,7 @@ import org.example.sqi_images.common.dto.page.response.PageResultDto;
 import org.example.sqi_images.common.exception.NotFoundException;
 import org.example.sqi_images.common.exception.type.ErrorType;
 import org.example.sqi_images.department.domain.Department;
-import org.example.sqi_images.department.repository.DepartmentRepository;
+import org.example.sqi_images.department.domain.repository.DepartmentRepository;
 import org.example.sqi_images.drive.common.dto.request.FileInfoUploadDto;
 import org.example.sqi_images.drive.common.dto.response.FileDownloadDto;
 import org.example.sqi_images.drive.common.dto.response.FileListDto;

--- a/src/main/java/org/example/sqi_images/employee/controller/ProfileController.java
+++ b/src/main/java/org/example/sqi_images/employee/controller/ProfileController.java
@@ -4,11 +4,9 @@ import lombok.RequiredArgsConstructor;
 import org.example.sqi_images.auth.authentication.annotation.AuthEmployee;
 import org.example.sqi_images.employee.domain.Employee;
 import org.example.sqi_images.employee.dto.request.CreateProfileDto;
-import org.example.sqi_images.employee.dto.response.ImageDataResponse;
 import org.example.sqi_images.employee.dto.response.ProfileDetailResponse;
 import org.example.sqi_images.employee.dto.response.ProfileResponseList;
 import org.example.sqi_images.employee.service.ProfileService;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -42,17 +40,5 @@ public class ProfileController {
     public ResponseEntity<ProfileDetailResponse> getProfileDetail(@PathVariable Long id) {
         ProfileDetailResponse profileDetail = profileService.getProfileDetail(id);
         return ResponseEntity.ok(profileDetail);
-    }
-
-    @GetMapping("/{profileId}/image")
-    public ResponseEntity<byte[]> getProfileImage(@PathVariable Long profileId) {
-        ImageDataResponse imageDataResponse = profileService.getProfileImage(profileId);
-
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.parseMediaType(imageDataResponse.contentType()));
-
-        return ResponseEntity.ok()
-                .headers(headers)
-                .body(imageDataResponse.imageData());
     }
 }

--- a/src/main/java/org/example/sqi_images/employee/domain/Employee.java
+++ b/src/main/java/org/example/sqi_images/employee/domain/Employee.java
@@ -9,6 +9,7 @@ import org.example.sqi_images.department.domain.Department;
 import org.example.sqi_images.drive.department.domain.DepartmentFile;
 import org.example.sqi_images.drive.global.domain.GlobalFile;
 import org.example.sqi_images.employee.dto.request.CreateProfileDto;
+import org.example.sqi_images.photo.domain.Photo;
 
 import java.util.List;
 
@@ -25,12 +26,11 @@ public class Employee extends BaseEntity {
     @Column(nullable = false)
     private String password;
 
-    @Column(nullable = false)
+    @Column(nullable = false, unique = true)
     private String name;
 
-    @Lob
     @Column
-    private byte[] photo;
+    private String photoUrl;
 
     @Column
     @Enumerated(EnumType.STRING)
@@ -44,15 +44,19 @@ public class Employee extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private PartType partType;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "department_id")
-    private Department department;
-
     @OneToMany(mappedBy = "employee", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<DepartmentFile> departmentFiles;
 
     @OneToMany(mappedBy = "employee", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<GlobalFile> globalFiles;
+
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    @JoinColumn(name = "photo_id")
+    private Photo photo;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "department_id")
+    private Department department;
 
     public Employee(String email, String password, String name) {
         this.email = email;
@@ -60,11 +64,12 @@ public class Employee extends BaseEntity {
         this.name = name;
     }
 
-    public void updateProfile(CreateProfileDto request, byte[] photoBytes, Department department) {
-        this.photo = photoBytes;
+    public void updateProfile(CreateProfileDto request, String photoUrl, Photo photo, Department department) {
+        this.photoUrl = photoUrl;
         this.languageType = LanguageType.fromValue(request.language());
         this.frameworkType = FrameworkType.fromValue(request.framework());
         this.partType = PartType.fromValue(request.part());
+        this.photo = photo;
         this.department = department;
     }
 }

--- a/src/main/java/org/example/sqi_images/employee/domain/repository/EmployeeRepository.java
+++ b/src/main/java/org/example/sqi_images/employee/domain/repository/EmployeeRepository.java
@@ -1,4 +1,4 @@
-package org.example.sqi_images.employee.repository;
+package org.example.sqi_images.employee.domain.repository;
 
 import org.example.sqi_images.employee.domain.Employee;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/src/main/java/org/example/sqi_images/employee/dto/response/ImageDataResponse.java
+++ b/src/main/java/org/example/sqi_images/employee/dto/response/ImageDataResponse.java
@@ -1,7 +1,0 @@
-package org.example.sqi_images.employee.dto.response;
-
-public record ImageDataResponse(byte[] imageData, String contentType) {
-    public static ImageDataResponse of(byte[] imageData, String contentType) {
-        return new ImageDataResponse(imageData, contentType);
-    }
-}

--- a/src/main/java/org/example/sqi_images/employee/dto/response/ProfileDetailResponse.java
+++ b/src/main/java/org/example/sqi_images/employee/dto/response/ProfileDetailResponse.java
@@ -12,7 +12,7 @@ public record ProfileDetailResponse(
         PartType partType,
         LanguageType languageType,
         FrameworkType frameworkType,
-        byte[] photo
+        String photoUrl
 ) {
     public static ProfileDetailResponse of(String name,
                                            String email,
@@ -20,7 +20,7 @@ public record ProfileDetailResponse(
                                            PartType partType,
                                            LanguageType languageType,
                                            FrameworkType frameworkType,
-                                           byte[] photo) {
-        return new ProfileDetailResponse(name, email, department, partType, languageType, frameworkType, photo);
+                                           String photoUrl) {
+        return new ProfileDetailResponse(name, email, department, partType, languageType, frameworkType, photoUrl);
     }
 }

--- a/src/main/java/org/example/sqi_images/employee/dto/response/ProfileResponse.java
+++ b/src/main/java/org/example/sqi_images/employee/dto/response/ProfileResponse.java
@@ -1,15 +1,11 @@
 package org.example.sqi_images.employee.dto.response;
 
-import jakarta.persistence.Lob;
-import lombok.Builder;
 
-
-@Builder
 public record ProfileResponse(
         Long profileId,
         String name,
-        @Lob byte[] photo) {
-    public static ProfileResponse of(Long profileId, String name, byte[] photo) {
-        return new ProfileResponse(profileId, name, photo);
+        String photoUrl ) {
+    public static ProfileResponse of(Long profileId, String name, String photoUrl) {
+        return new ProfileResponse(profileId, name, photoUrl);
     }
 }

--- a/src/main/java/org/example/sqi_images/photo/controller/PhotoController.java
+++ b/src/main/java/org/example/sqi_images/photo/controller/PhotoController.java
@@ -1,0 +1,28 @@
+package org.example.sqi_images.photo.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.example.sqi_images.photo.dto.response.PhotoDataResponse;
+import org.example.sqi_images.photo.service.PhotoService;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
+
+@RestController
+@RequestMapping("/api/images")
+@RequiredArgsConstructor
+public class PhotoController {
+
+    private final PhotoService photoService;
+
+    @GetMapping("/{photoId}")
+    public ResponseEntity<StreamingResponseBody> getImage(@PathVariable Long photoId) {
+        PhotoDataResponse photoDataResponse = photoService.getImage(photoId);
+        return ResponseEntity.ok()
+                .contentType(MediaType.IMAGE_JPEG)
+                .body(outputStream -> {
+                    outputStream.write(photoDataResponse.photoData());
+                    outputStream.flush();
+                });
+    }
+}

--- a/src/main/java/org/example/sqi_images/photo/domain/Photo.java
+++ b/src/main/java/org/example/sqi_images/photo/domain/Photo.java
@@ -1,0 +1,25 @@
+package org.example.sqi_images.photo.domain;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.example.sqi_images.common.domain.BaseEntity;
+import org.example.sqi_images.employee.domain.Employee;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "photos")
+public class Photo extends BaseEntity {
+
+    @Lob
+    @Column(nullable = false)
+    private byte[] photoData;
+
+    @OneToOne(mappedBy = "photo")
+    private Employee employee;
+}

--- a/src/main/java/org/example/sqi_images/photo/domain/repository/PhotoRepository.java
+++ b/src/main/java/org/example/sqi_images/photo/domain/repository/PhotoRepository.java
@@ -1,0 +1,7 @@
+package org.example.sqi_images.photo.domain.repository;
+
+import org.example.sqi_images.photo.domain.Photo;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PhotoRepository extends JpaRepository<Photo, Long> {
+}

--- a/src/main/java/org/example/sqi_images/photo/dto/response/PhotoDataResponse.java
+++ b/src/main/java/org/example/sqi_images/photo/dto/response/PhotoDataResponse.java
@@ -1,0 +1,7 @@
+package org.example.sqi_images.photo.dto.response;
+
+public record PhotoDataResponse(byte[] photoData) {
+    public static PhotoDataResponse from(byte[] photoData) {
+        return new PhotoDataResponse(photoData);
+    }
+}

--- a/src/main/java/org/example/sqi_images/photo/service/PhotoService.java
+++ b/src/main/java/org/example/sqi_images/photo/service/PhotoService.java
@@ -1,0 +1,36 @@
+package org.example.sqi_images.photo.service;
+
+import lombok.RequiredArgsConstructor;
+import org.example.sqi_images.common.exception.NotFoundException;
+import org.example.sqi_images.employee.domain.Employee;
+import org.example.sqi_images.photo.dto.response.PhotoDataResponse;
+import org.example.sqi_images.photo.domain.Photo;
+import org.example.sqi_images.photo.domain.repository.PhotoRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+
+import static org.example.sqi_images.common.exception.type.ErrorType.PHOTO_NOT_FOUND_ERROR;
+
+@Service
+@RequiredArgsConstructor
+public class PhotoService {
+
+    private final PhotoRepository photoRepository;
+
+    @Transactional
+    public Photo saveImage(Employee employee, MultipartFile file) throws IOException {
+        Photo photo = new Photo(file.getBytes(), employee);
+        return photoRepository.save(photo);
+    }
+
+    @Transactional(readOnly = true)
+    public PhotoDataResponse getImage(Long photoId) {
+        Photo photo = photoRepository.findById(photoId)
+                .orElseThrow(() -> new NotFoundException(PHOTO_NOT_FOUND_ERROR));
+
+        return PhotoDataResponse.from(photo.getPhotoData());
+    }
+}


### PR DESCRIPTION
## Description
- 프로필 사진 조회 시 바이트배열 대신 사진 조회 API를 반환하게끔 변경
- 이미지 데이터 저장을 위한 사진 엔티티 생성
- S3 로직 직접 구현
## Changes
### Employee
- [x] ProfileDetailResponse
- [x] ProfileResponse
- [x] ProfileService
### Photo
- [x] Photo
- [x] PhotoRepository
- [x] PhotoDataResponse
- [x] PhotoService
- [x] PhotoController
## Additional context

Closes #28 