### PR TITLE
Feature/#35 파일 확장자 추출 방식 변경

### DIFF
--- a/src/main/java/org/example/sqi_images/common/constant/Constants.java
+++ b/src/main/java/org/example/sqi_images/common/constant/Constants.java
@@ -1,5 +1,6 @@
 package org.example.sqi_images.common.constant;
 
+import java.text.DecimalFormat;
 import java.util.List;
 public class Constants {
 
@@ -16,4 +17,9 @@ public class Constants {
 
     // Drive
     public static final String ADD_DRIVE_API_PATH = "/api/drives/**";
+
+    // FileUtil
+    public static final long KB = 1024;
+    public static final long MB = 1024 * KB;
+    public static final DecimalFormat DECIMAL_FORMAT = new DecimalFormat("#.##");
 }

--- a/src/main/java/org/example/sqi_images/common/exception/type/ErrorType.java
+++ b/src/main/java/org/example/sqi_images/common/exception/type/ErrorType.java
@@ -10,6 +10,7 @@ public enum ErrorType {
     // BAD_REQUEST
     INVALID_PAGE_REQUEST_ERROR(40000, "요청한 페이지 번호가 유효하지 않습니다."),
     UPLOADED_FILE_EMPTY_ERROR(40001, "업로드된 파일이 비어있습니다."),
+    DUPLICATED_FILE_NAME_ERROR(40002, "이미 존재하는 파일 이름입니다."),
 
     // UNAUTHORIZED
     NOT_AUTHENTICATED_ERROR(40100, "인증되지 않았습니다."),

--- a/src/main/java/org/example/sqi_images/drive/common/dto/request/FileInfoUploadDto.java
+++ b/src/main/java/org/example/sqi_images/drive/common/dto/request/FileInfoUploadDto.java
@@ -1,9 +1,0 @@
-package org.example.sqi_images.drive.common.dto.request;
-
-import jakarta.validation.constraints.NotBlank;
-
-public record FileInfoUploadDto(
-        @NotBlank(message = "파일 이름을 작성해주세요.")
-        String fileName
-) {
-}

--- a/src/main/java/org/example/sqi_images/drive/common/util/FileUtil.java
+++ b/src/main/java/org/example/sqi_images/drive/common/util/FileUtil.java
@@ -1,25 +1,16 @@
 package org.example.sqi_images.drive.common.util;
-import org.apache.tika.Tika;
-import org.apache.tika.mime.MimeType;
-import org.apache.tika.mime.MimeTypes;
 import org.example.sqi_images.drive.common.dto.response.FileDownloadDto;
 import org.springframework.http.ContentDisposition;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 
-import java.io.IOException;
-import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
-import java.text.DecimalFormat;
+
+import static org.example.sqi_images.common.constant.Constants.*;
 
 @Component
 public class FileUtil {
-
-    public static final Tika tika = new Tika();
-    private static final long KB = 1024;
-    private static final long MB = 1024 * KB;
-    private static final DecimalFormat DECIMAL_FORMAT = new DecimalFormat("#.##");
 
     /**
      * 파일 다운로드에 필요한 HttpHeaders 생성 메서드
@@ -27,6 +18,7 @@ public class FileUtil {
     public static HttpHeaders createFileDownloadHeaders(FileDownloadDto fileDownloadDto) {
         HttpHeaders headers = new HttpHeaders();
         String fileName = fileDownloadDto.fileName();
+
         ContentDisposition contentDisposition = ContentDisposition.builder("attachment")
                 .filename(fileName, StandardCharsets.UTF_8)
                 .build();
@@ -52,16 +44,20 @@ public class FileUtil {
     }
 
     /**
-     * 파일 확장자 추출 메서드
+     * 파일 이름에서 확장자 추출
      */
-     public static String getFileExtensionByMimeType(InputStream input) throws IOException {
-        MimeTypes allTypes = MimeTypes.getDefaultMimeTypes();
-        String mimeType = tika.detect(input);
-        try {
-            MimeType type = allTypes.forName(mimeType);
-            return type.getExtension();
-        } catch (Exception e) {
-            return "";
+    public static String getExtensionByFileName(String fileName) {
+        if (fileName == null) {
+            return null; // 파일 이름이 null인 경우
+        }
+
+        int lastIndexOfDot = fileName.lastIndexOf('.');
+        if (lastIndexOfDot == -1) {
+            return ""; // 확장자가 없는 경우
+        } else if (lastIndexOfDot == fileName.length() - 1) {
+            return ""; // 파일 이름이 점으로 끝나는 경우
+        } else {
+            return fileName.substring(lastIndexOfDot + 1);
         }
     }
 }

--- a/src/main/java/org/example/sqi_images/drive/department/controller/DepartmentFileController.java
+++ b/src/main/java/org/example/sqi_images/drive/department/controller/DepartmentFileController.java
@@ -1,18 +1,19 @@
 package org.example.sqi_images.drive.department.controller;
 
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.example.sqi_images.auth.authentication.annotation.AuthEmployee;
 import org.example.sqi_images.common.aop.annotation.DepartmentMember;
 import org.example.sqi_images.common.dto.page.request.PageRequestDto;
 import org.example.sqi_images.common.dto.page.response.PageResultDto;
-import org.example.sqi_images.drive.common.dto.request.FileInfoUploadDto;
 import org.example.sqi_images.drive.common.dto.response.FileDownloadDto;
 import org.example.sqi_images.drive.common.dto.response.FileListDto;
 import org.example.sqi_images.drive.department.domain.DepartmentFile;
 import org.example.sqi_images.drive.department.service.DepartmentFileService;
 import org.example.sqi_images.employee.domain.Employee;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -32,20 +33,22 @@ public class DepartmentFileController {
     @DepartmentMember
     public ResponseEntity<String> uploadDepartmentFile(@AuthEmployee Employee employee,
                                                        @PathVariable Long departmentId,
-                                                       @RequestPart("file") MultipartFile file,
-                                                       @RequestPart("fileName") @Valid FileInfoUploadDto fileInfoUploadDto) throws IOException {
-        departmentFileService.uploadDepartmentFile(employee, departmentId, fileInfoUploadDto, file);
+                                                       @RequestPart("file") MultipartFile file) throws IOException {
+        departmentFileService.uploadDepartmentFile(employee, departmentId, file);
         return ResponseEntity.status(HttpStatus.CREATED).body("부서별 공유 드라이브 파일 업로드 완료");
     }
 
     @GetMapping("/download/{fileId}")
     @DepartmentMember
-    public ResponseEntity<byte[]> downloadDepartmentFile(@PathVariable Long departmentId,
-                                                         @PathVariable Long fileId) {
+    public ResponseEntity<ByteArrayResource> downloadDepartmentFile(@PathVariable Long departmentId,
+                                                                    @PathVariable Long fileId) {
         FileDownloadDto fileDownloadDto = departmentFileService.downloadDepartmentFile(fileId);
+        HttpHeaders headers = createFileDownloadHeaders(fileDownloadDto);
+
         return ResponseEntity.ok()
-                .headers(createFileDownloadHeaders(fileDownloadDto))
-                .body(fileDownloadDto.data());
+                .contentType(MediaType.valueOf(fileDownloadDto.contentType()))
+                .headers(headers)
+                .body(new ByteArrayResource(fileDownloadDto.data()));
     }
 
     @GetMapping("/list")

--- a/src/main/java/org/example/sqi_images/drive/department/service/DepartmentFileService.java
+++ b/src/main/java/org/example/sqi_images/drive/department/service/DepartmentFileService.java
@@ -8,7 +8,6 @@ import org.example.sqi_images.common.exception.NotFoundException;
 import org.example.sqi_images.common.exception.type.ErrorType;
 import org.example.sqi_images.department.domain.Department;
 import org.example.sqi_images.department.domain.repository.DepartmentRepository;
-import org.example.sqi_images.drive.common.dto.request.FileInfoUploadDto;
 import org.example.sqi_images.drive.common.dto.response.FileDownloadDto;
 import org.example.sqi_images.drive.common.dto.response.FileListDto;
 import org.example.sqi_images.drive.department.domain.DepartmentFile;
@@ -20,7 +19,6 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
-import java.io.InputStream;
 
 import static org.example.sqi_images.common.exception.type.ErrorType.DEPARTMENT_NOT_FOUND_ERROR;
 import static org.example.sqi_images.common.exception.type.ErrorType.UPLOADED_FILE_EMPTY_ERROR;
@@ -34,24 +32,27 @@ public class DepartmentFileService {
     private final DepartmentRepository departmentRepository;
 
     @Transactional
-    public void uploadDepartmentFile(Employee employee, Long departmentId, FileInfoUploadDto fileInfoUploadDto, MultipartFile file) throws IOException {
+    public void uploadDepartmentFile(Employee employee, Long departmentId, MultipartFile file) throws IOException {
         if (file.isEmpty()) {
             throw new BadRequestException(UPLOADED_FILE_EMPTY_ERROR);
         }
+        // 파일 데이터 추출
         byte[] fileData = file.getBytes();
         long fileSize = file.getSize();
-        String fileName = generateUniqueFileName(fileInfoUploadDto.fileName());
+
+        // 파일 이름, 확장자 추출
+        String fileName = generateUniqueFileName(file.getOriginalFilename());
+        String fileExtension = getExtensionByFileName(fileName);
+
         String formattedFileSize = formatFileSize(fileSize);
         Department department = departmentRepository.findById(departmentId).orElseThrow(() -> new NotFoundException(DEPARTMENT_NOT_FOUND_ERROR));
 
-        try (InputStream input = file.getInputStream()) {
-            String contentType = tika.detect(input);
-            String fileExtension = getFileExtensionByMimeType(input);
-            DepartmentFile newFile = new DepartmentFile(fileName, fileData, contentType, fileExtension, fileSize, formattedFileSize, employee, department);
-            departmentFileRepository.save(newFile);
-        }
+        String contentType = file.getContentType();
+
+        DepartmentFile newFile = new DepartmentFile(fileName, fileData, contentType, fileExtension, fileSize, formattedFileSize, employee, department);
+        departmentFileRepository.save(newFile);
     }
-    
+
     public FileDownloadDto downloadDepartmentFile(Long fileId) {
         DepartmentFile file = departmentFileRepository.findById(fileId)
                 .orElseThrow(() -> new NotFoundException(ErrorType.FILE_NOT_FOUND_ERROR));

--- a/src/main/java/org/example/sqi_images/drive/department/service/DepartmentFileService.java
+++ b/src/main/java/org/example/sqi_images/drive/department/service/DepartmentFileService.java
@@ -20,8 +20,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
 
-import static org.example.sqi_images.common.exception.type.ErrorType.DEPARTMENT_NOT_FOUND_ERROR;
-import static org.example.sqi_images.common.exception.type.ErrorType.UPLOADED_FILE_EMPTY_ERROR;
+import static org.example.sqi_images.common.exception.type.ErrorType.*;
 import static org.example.sqi_images.drive.common.util.FileUtil.*;
 
 @Service
@@ -36,13 +35,17 @@ public class DepartmentFileService {
         if (file.isEmpty()) {
             throw new BadRequestException(UPLOADED_FILE_EMPTY_ERROR);
         }
+
+        String fileName = file.getOriginalFilename();
+        // 중복 파일 이름 검사
+        if (departmentFileRepository.existsByFileName(fileName)) {
+            throw new BadRequestException(DUPLICATED_FILE_NAME_ERROR);
+        }
+        String fileExtension = getExtensionByFileName(fileName);
+
         // 파일 데이터 추출
         byte[] fileData = file.getBytes();
         long fileSize = file.getSize();
-
-        // 파일 이름, 확장자 추출
-        String fileName = generateUniqueFileName(file.getOriginalFilename());
-        String fileExtension = getExtensionByFileName(fileName);
 
         String formattedFileSize = formatFileSize(fileSize);
         Department department = departmentRepository.findById(departmentId).orElseThrow(() -> new NotFoundException(DEPARTMENT_NOT_FOUND_ERROR));
@@ -69,15 +72,5 @@ public class DepartmentFileService {
     public PageResultDto<FileListDto, DepartmentFile> getDepartmentFileList(Long departmentId, PageRequestDto pageRequestDto) {
         Page<DepartmentFile> result = departmentFileRepository.findByDepartmentId(departmentId, pageRequestDto.toPageable());
         return new PageResultDto<>(result, FileListDto::ofDepartmentFile);
-    }
-
-    private String generateUniqueFileName(String originalName) {
-        int count = 0;
-        String fileName = originalName;
-        while (departmentFileRepository.existsByFileName(fileName)) {
-            count++;
-            fileName = originalName + " (" + count + ")";
-        }
-        return fileName;
     }
 }

--- a/src/main/java/org/example/sqi_images/drive/global/controller/GlobalFileController.java
+++ b/src/main/java/org/example/sqi_images/drive/global/controller/GlobalFileController.java
@@ -1,17 +1,18 @@
 package org.example.sqi_images.drive.global.controller;
 
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.example.sqi_images.auth.authentication.annotation.AuthEmployee;
 import org.example.sqi_images.common.dto.page.request.PageRequestDto;
 import org.example.sqi_images.common.dto.page.response.PageResultDto;
-import org.example.sqi_images.drive.common.dto.request.FileInfoUploadDto;
 import org.example.sqi_images.drive.common.dto.response.FileDownloadDto;
 import org.example.sqi_images.drive.common.dto.response.FileListDto;
 import org.example.sqi_images.drive.global.domain.GlobalFile;
 import org.example.sqi_images.drive.global.service.GlobalFileService;
 import org.example.sqi_images.employee.domain.Employee;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -29,18 +30,20 @@ public class GlobalFileController {
 
     @PostMapping(value = "/upload", consumes = "multipart/form-data")
     public ResponseEntity<String> uploadFile(@AuthEmployee Employee employee,
-                                             @RequestPart("file") MultipartFile file,
-                                             @RequestPart("fileName") @Valid FileInfoUploadDto fileInfoUploadDto) throws IOException {
-        globalFileService.uploadGlobalFile(employee, fileInfoUploadDto, file);
+                                             @RequestPart("file") MultipartFile file) throws IOException {
+        globalFileService.uploadGlobalFile(employee, file);
         return ResponseEntity.status(HttpStatus.CREATED).body("전체 공유 드라이브 파일 업로드 완료");
     }
 
     @GetMapping("/download/{fileId}")
-    public ResponseEntity<byte[]> downloadFile(@PathVariable Long fileId) {
+    public ResponseEntity<ByteArrayResource> downloadFile(@PathVariable Long fileId) {
         FileDownloadDto fileDownloadDto = globalFileService.downloadGlobalFile(fileId);
+        HttpHeaders headers = createFileDownloadHeaders(fileDownloadDto);
+
         return ResponseEntity.ok()
-                .headers(createFileDownloadHeaders(fileDownloadDto))
-                .body(fileDownloadDto.data());
+                .contentType(MediaType.valueOf(fileDownloadDto.contentType()))
+                .headers(headers)
+                .body(new ByteArrayResource(fileDownloadDto.data()));
     }
 
     @GetMapping("/list")

--- a/src/main/java/org/example/sqi_images/drive/global/service/GlobalFileService.java
+++ b/src/main/java/org/example/sqi_images/drive/global/service/GlobalFileService.java
@@ -8,7 +8,6 @@ import org.example.sqi_images.common.exception.NotFoundException;
 import org.example.sqi_images.common.exception.type.ErrorType;
 import org.example.sqi_images.department.domain.Department;
 import org.example.sqi_images.department.domain.repository.DepartmentRepository;
-import org.example.sqi_images.drive.common.dto.request.FileInfoUploadDto;
 import org.example.sqi_images.drive.common.dto.response.FileDownloadDto;
 import org.example.sqi_images.drive.common.dto.response.FileListDto;
 import org.example.sqi_images.drive.global.domain.GlobalFile;
@@ -20,7 +19,6 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
-import java.io.InputStream;
 
 import static org.example.sqi_images.common.exception.type.ErrorType.DEPARTMENT_NOT_FOUND_ERROR;
 import static org.example.sqi_images.common.exception.type.ErrorType.UPLOADED_FILE_EMPTY_ERROR;
@@ -34,25 +32,24 @@ public class GlobalFileService {
     private final DepartmentRepository departmentRepository;
 
     @Transactional
-    public void uploadGlobalFile(Employee employee, FileInfoUploadDto fileInfoUploadDto, MultipartFile file) throws IOException {
-        Department department = departmentRepository.findById(employee.getDepartment().getId())
-                .orElseThrow(() -> new NotFoundException(DEPARTMENT_NOT_FOUND_ERROR));
-
+    public void uploadGlobalFile(Employee employee, MultipartFile file) throws IOException {
         if (file.isEmpty()) {
             throw new BadRequestException(UPLOADED_FILE_EMPTY_ERROR);
         }
 
         byte[] fileData = file.getBytes();
         long fileSize = file.getSize();
-        String fileName = generateUniqueFileName(fileInfoUploadDto.fileName());
-        String formattedFileSize = formatFileSize(fileSize);
 
-        try (InputStream input = file.getInputStream()) {
-            String contentType = tika.detect(input);
-            String fileExtension = getFileExtensionByMimeType(input);
-            GlobalFile newFile = new GlobalFile(fileName, fileData, contentType, fileExtension, fileSize, formattedFileSize, employee, department);
-            globalFileRepository.save(newFile);
-        }
+        String fileName = generateUniqueFileName(file.getOriginalFilename());
+        String fileExtension = getExtensionByFileName(fileName);
+        Department department = departmentRepository.findById(employee.getDepartment().getId())
+                .orElseThrow(() -> new NotFoundException(DEPARTMENT_NOT_FOUND_ERROR));
+
+        String formattedFileSize = formatFileSize(fileSize);
+        String contentType = file.getContentType();
+
+        GlobalFile newFile = new GlobalFile(fileName, fileData, contentType, fileExtension, fileSize, formattedFileSize, employee, department);
+        globalFileRepository.save(newFile);
     }
 
     public FileDownloadDto downloadGlobalFile(Long fileId) {


### PR DESCRIPTION
## Description
- 파일 확장자 추출 방식 변경
## Changes
### Controller
- [x] DepartmentFileController
- [x] GlobalFileController
### Service
- [x] DepartmentFileService
- [x] GlobalFileService
### Util
- [x] FileUtil
## Additional context
- pdf, png, jpeg 등 파일은 정상 다운로드 되는데, 엑셀 파일(.xlsx)만 다운로드 시 깨지는 문제 발생
- 브라우저에서 테스트해본 결과 엑셀 파일만 확장자 없이 다운로드되고 있어 깨지는 문제 확인
- 사용자가 파일 업로드 시 저장할 이름을 받는 방식 -> 파일 원본 이름 그대로 업로드되는 방식으로 변경
- 만약 원래 방식에서 하려면, 사용자가 업로드할 파일 이름 필드와 파일의 원본 이름에서 "." 유무 확인과 뒤 문자열을 Substring하는 방식으로 확장자만 추출하여 fileExtension 칼럼에 저장해두고, 다운로드 시 fileName과 fileExtension 문자열을 더하게끔 하면 된다.

Closes #35 