### PR TITLE
Feature/#41 프로필 조회 시에만 사용되는 필드 엔티티 분리

### DIFF
--- a/src/main/java/org/example/sqi_images/auth/authentication/interceptor/AuthenticationInterceptor.java
+++ b/src/main/java/org/example/sqi_images/auth/authentication/interceptor/AuthenticationInterceptor.java
@@ -6,21 +6,18 @@ import lombok.RequiredArgsConstructor;
 import org.example.sqi_images.auth.authentication.AccessTokenProvider;
 import org.example.sqi_images.auth.authentication.AuthenticationContext;
 import org.example.sqi_images.auth.authentication.AuthenticationExtractor;
-import org.example.sqi_images.common.exception.NotFoundException;
 import org.example.sqi_images.employee.domain.Employee;
-import org.example.sqi_images.employee.domain.repository.EmployeeRepository;
+import org.example.sqi_images.employee.service.EmployeeService;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
 
 import java.io.UnsupportedEncodingException;
 
-import static org.example.sqi_images.common.exception.type.ErrorType.EMPLOYEE_NOT_FOUND_ERROR;
-
 @Component
 @RequiredArgsConstructor
 public class AuthenticationInterceptor implements HandlerInterceptor {
 
-    private final EmployeeRepository employeeRepository;
+    private final EmployeeService employeeService;
     private final AuthenticationContext authenticationContext;
     private final AccessTokenProvider accessTokenProvider;
 
@@ -28,12 +25,8 @@ public class AuthenticationInterceptor implements HandlerInterceptor {
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws UnsupportedEncodingException {
         String accessToken = AuthenticationExtractor.extract(request);
         Long employeeId = Long.valueOf(accessTokenProvider.getPayload(accessToken));
-        Employee employee = findExistingEmployee(employeeId);
+        Employee employee = employeeService.findExistingEmployee(employeeId);
         authenticationContext.setPrincipal(employee);
         return true;
-    }
-
-    private Employee findExistingEmployee(Long employeeId) {
-        return employeeRepository.findById(employeeId).orElseThrow(() -> new NotFoundException(EMPLOYEE_NOT_FOUND_ERROR));
     }
 }

--- a/src/main/java/org/example/sqi_images/department/domain/Department.java
+++ b/src/main/java/org/example/sqi_images/department/domain/Department.java
@@ -7,11 +7,9 @@ import lombok.NoArgsConstructor;
 import org.example.sqi_images.common.domain.BaseEntity;
 import org.example.sqi_images.common.domain.DepartmentType;
 import org.example.sqi_images.drive.department.domain.DepartmentFile;
-import org.example.sqi_images.drive.global.domain.GlobalFile;
 import org.example.sqi_images.employee.domain.Employee;
 import org.example.sqi_images.part.domain.Part;
 
-import java.util.ArrayList;
 import java.util.List;
 
 @Entity
@@ -26,13 +24,10 @@ public class Department extends BaseEntity {
     private DepartmentType departmentType;
 
     @OneToMany(mappedBy = "department", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<Part> parts = new ArrayList<>();
+    private List<Part> parts;
 
     @OneToMany(mappedBy = "department")
     private List<Employee> employees;
-
-    @OneToMany(mappedBy = "department", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<GlobalFile> globalFiles;
 
     @OneToMany(mappedBy = "department", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<DepartmentFile> departmentFiles;

--- a/src/main/java/org/example/sqi_images/department/service/DepartmentService.java
+++ b/src/main/java/org/example/sqi_images/department/service/DepartmentService.java
@@ -15,7 +15,7 @@ public class DepartmentService {
 
     private final DepartmentRepository departmentRepository;
 
-    public Department findExistingDepartmentByType(Long departmentId) {
+    public Department findExistingDepartmentById(Long departmentId) {
         return departmentRepository.findById(departmentId)
                 .orElseThrow(() -> new NotFoundException(DEPARTMENT_NOT_FOUND_ERROR));
     }

--- a/src/main/java/org/example/sqi_images/drive/department/service/DepartmentFileService.java
+++ b/src/main/java/org/example/sqi_images/drive/department/service/DepartmentFileService.java
@@ -45,7 +45,7 @@ public class DepartmentFileService {
         String formattedFileSize = formatFileSize(fileSize);
         String contentType = file.getContentType();
 
-        Department department = departmentService.findExistingDepartmentByType(departmentId);
+        Department department = departmentService.findExistingDepartmentById(departmentId);
 
         DepartmentFile newFile = new DepartmentFile(
                 fileName,

--- a/src/main/java/org/example/sqi_images/drive/global/domain/GlobalFile.java
+++ b/src/main/java/org/example/sqi_images/drive/global/domain/GlobalFile.java
@@ -6,7 +6,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.example.sqi_images.common.domain.BaseEntity;
-import org.example.sqi_images.department.domain.Department;
 import org.example.sqi_images.employee.domain.Employee;
 
 @Entity
@@ -39,8 +38,4 @@ public class GlobalFile extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "employee_id", nullable = false)
     private Employee employee;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "department_id", nullable = false)
-    private Department department;
 }

--- a/src/main/java/org/example/sqi_images/drive/global/dto/response/GlobalFileListDto.java
+++ b/src/main/java/org/example/sqi_images/drive/global/dto/response/GlobalFileListDto.java
@@ -17,7 +17,7 @@ public record GlobalFileListDto(
     public static GlobalFileListDto of(GlobalFile file) {
         return new GlobalFileListDto(
                 file.getId(),
-                file.getDepartment().getDepartmentType(),
+                file.getEmployee().getDepartment().getDepartmentType(),
                 file.getFileName(),
                 file.getEmployee().getName(),
                 file.getCreatedAt().format(FORMATTER),

--- a/src/main/java/org/example/sqi_images/drive/global/service/GlobalFileService.java
+++ b/src/main/java/org/example/sqi_images/drive/global/service/GlobalFileService.java
@@ -5,8 +5,6 @@ import org.example.sqi_images.common.dto.page.request.PageRequestDto;
 import org.example.sqi_images.common.dto.page.response.PageResultDto;
 import org.example.sqi_images.common.exception.NotFoundException;
 import org.example.sqi_images.common.exception.type.ErrorType;
-import org.example.sqi_images.department.domain.Department;
-import org.example.sqi_images.department.service.DepartmentService;
 import org.example.sqi_images.drive.common.dto.response.FileDownloadDto;
 import org.example.sqi_images.drive.global.domain.GlobalFile;
 import org.example.sqi_images.drive.global.domain.repository.GlobalFileRepository;
@@ -26,7 +24,6 @@ import static org.example.sqi_images.common.util.FileUtil.validateDuplicatedFile
 @RequiredArgsConstructor
 public class GlobalFileService {
 
-    private final DepartmentService departmentService;
     private final GlobalFileRepository globalFileRepository;
 
     /**
@@ -44,10 +41,6 @@ public class GlobalFileService {
         String formattedFileSize = formatFileSize(fileSize);
         String contentType = file.getContentType();
 
-        Department department = departmentService.findExistingDepartmentByType(
-                employee.getDepartment().getId()
-        );
-
         GlobalFile newFile = new GlobalFile(
                 fileName,
                 fileData,
@@ -55,8 +48,7 @@ public class GlobalFileService {
                 fileExtension,
                 fileSize,
                 formattedFileSize,
-                employee,
-                department
+                employee
         );
         globalFileRepository.save(newFile);
     }

--- a/src/main/java/org/example/sqi_images/employee/domain/Employee.java
+++ b/src/main/java/org/example/sqi_images/employee/domain/Employee.java
@@ -8,9 +8,7 @@ import org.example.sqi_images.common.domain.*;
 import org.example.sqi_images.department.domain.Department;
 import org.example.sqi_images.drive.department.domain.DepartmentFile;
 import org.example.sqi_images.drive.global.domain.GlobalFile;
-import org.example.sqi_images.employee.dto.request.CreateProfileDto;
 import org.example.sqi_images.part.domain.Part;
-import org.example.sqi_images.photo.domain.Photo;
 
 import java.util.List;
 
@@ -30,20 +28,17 @@ public class Employee extends BaseEntity {
     @Column(nullable = false, unique = true)
     private String name;
 
-    @Column
-    private String photoUrl;
-
-    @Column
-    @Enumerated(EnumType.STRING)
-    private LanguageType languageType;
-
-    @Column
-    @Enumerated(EnumType.STRING)
-    private FrameworkType frameworkType;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "department_id")
+    private Department department;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "part_id")
     private Part part;
+
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    @JoinColumn(name = "detail_id")
+    private EmployeeDetail detail;
 
     @OneToMany(mappedBy = "employee", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<DepartmentFile> departmentFiles;
@@ -51,26 +46,18 @@ public class Employee extends BaseEntity {
     @OneToMany(mappedBy = "employee", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<GlobalFile> globalFiles;
 
-    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
-    @JoinColumn(name = "photo_id")
-    private Photo photo;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "department_id")
-    private Department department;
-
     public Employee(String email, String password, String name) {
         this.email = email;
         this.password = password;
         this.name = name;
     }
 
-    public void updateProfile(CreateProfileDto request, String photoUrl, Photo photo, Department department, Part part) {
-        this.photoUrl = photoUrl;
-        this.languageType = LanguageType.fromValue(request.language());
-        this.frameworkType = FrameworkType.fromValue(request.framework());
+    public void updateDepartmentAndPart(Department department, Part part) {
         this.part = part;
-        this.photo = photo;
         this.department = department;
+    }
+
+    public void setEmployeeDetailInfo(EmployeeDetail detail) {
+        this.detail = detail;
     }
 }

--- a/src/main/java/org/example/sqi_images/employee/domain/EmployeeDetail.java
+++ b/src/main/java/org/example/sqi_images/employee/domain/EmployeeDetail.java
@@ -1,0 +1,45 @@
+package org.example.sqi_images.employee.domain;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.example.sqi_images.common.domain.BaseEntity;
+import org.example.sqi_images.common.domain.FrameworkType;
+import org.example.sqi_images.common.domain.LanguageType;
+import org.example.sqi_images.photo.domain.Photo;
+
+@Entity
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Table(name = "employee_details")
+public class EmployeeDetail extends BaseEntity {
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private LanguageType languageType;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private FrameworkType frameworkType;
+
+    @Column(nullable = false)
+    private String photoUrl;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "employee_id", unique = true)
+    private Employee employee;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "photo_id")
+    private Photo photo;
+
+    public EmployeeDetail(String language, String framework, String photoUrl, Photo photo, Employee employee) {
+        this.employee = employee;
+        this.languageType = LanguageType.fromValue(language);
+        this.frameworkType = FrameworkType.fromValue(framework);
+        this.photo = photo;
+        this.photoUrl = photoUrl;
+    }
+}

--- a/src/main/java/org/example/sqi_images/employee/domain/repository/EmployeeDetailRepository.java
+++ b/src/main/java/org/example/sqi_images/employee/domain/repository/EmployeeDetailRepository.java
@@ -1,0 +1,8 @@
+package org.example.sqi_images.employee.domain.repository;
+
+import org.example.sqi_images.employee.domain.EmployeeDetail;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EmployeeDetailRepository extends JpaRepository<EmployeeDetail, Long> {
+    boolean existsByEmployeeId(Long employeeId);
+}

--- a/src/main/java/org/example/sqi_images/employee/domain/repository/EmployeeRepository.java
+++ b/src/main/java/org/example/sqi_images/employee/domain/repository/EmployeeRepository.java
@@ -2,7 +2,9 @@ package org.example.sqi_images.employee.domain.repository;
 
 import org.example.sqi_images.employee.domain.Employee;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface EmployeeRepository extends JpaRepository<Employee, Long> {
@@ -10,4 +12,6 @@ public interface EmployeeRepository extends JpaRepository<Employee, Long> {
     Optional<Employee> findByEmail(String email);
     boolean existsByName(String name);
     boolean existsByEmail(String email);
+    @Query("SELECT e FROM Employee e JOIN FETCH e.detail")
+    List<Employee> findAllWithDetails();
 }

--- a/src/main/java/org/example/sqi_images/employee/dto/response/ProfileDetailResponse.java
+++ b/src/main/java/org/example/sqi_images/employee/dto/response/ProfileDetailResponse.java
@@ -6,6 +6,7 @@ import org.example.sqi_images.common.domain.LanguageType;
 import org.example.sqi_images.common.domain.PartType;
 
 public record ProfileDetailResponse(
+        Long employeeId,
         String name,
         String email,
         DepartmentType department,
@@ -14,13 +15,15 @@ public record ProfileDetailResponse(
         FrameworkType frameworkType,
         String photoUrl
 ) {
-    public static ProfileDetailResponse of(String name,
-                                           String email,
-                                           DepartmentType department,
-                                           PartType partType,
-                                           LanguageType languageType,
-                                           FrameworkType frameworkType,
-                                           String photoUrl) {
-        return new ProfileDetailResponse(name, email, department, partType, languageType, frameworkType, photoUrl);
+    public static ProfileDetailResponse of(
+            Long employeeId,
+            String name,
+            String email,
+            DepartmentType department,
+            PartType partType,
+            LanguageType languageType,
+            FrameworkType frameworkType,
+            String photoUrl) {
+        return new ProfileDetailResponse(employeeId, name, email, department, partType, languageType, frameworkType, photoUrl);
     }
 }

--- a/src/main/java/org/example/sqi_images/employee/dto/response/ProfileResponse.java
+++ b/src/main/java/org/example/sqi_images/employee/dto/response/ProfileResponse.java
@@ -2,7 +2,7 @@ package org.example.sqi_images.employee.dto.response;
 
 
 public record ProfileResponse(
-        Long profileId,
+        Long employeeId,
         String name,
         String photoUrl ) {
     public static ProfileResponse of(Long profileId, String name, String photoUrl) {

--- a/src/main/java/org/example/sqi_images/employee/service/EmployeeService.java
+++ b/src/main/java/org/example/sqi_images/employee/service/EmployeeService.java
@@ -1,0 +1,21 @@
+package org.example.sqi_images.employee.service;
+
+import lombok.RequiredArgsConstructor;
+import org.example.sqi_images.common.exception.NotFoundException;
+import org.example.sqi_images.employee.domain.Employee;
+import org.example.sqi_images.employee.domain.repository.EmployeeRepository;
+import org.springframework.stereotype.Service;
+
+import static org.example.sqi_images.common.exception.type.ErrorType.EMPLOYEE_NOT_FOUND_ERROR;
+
+@Service
+@RequiredArgsConstructor
+public class EmployeeService {
+
+    private final EmployeeRepository employeeRepository;
+
+    public Employee findExistingEmployee(Long employeeId) {
+        return employeeRepository.findById(employeeId)
+                .orElseThrow(() -> new NotFoundException(EMPLOYEE_NOT_FOUND_ERROR));
+    }
+}

--- a/src/main/java/org/example/sqi_images/photo/domain/Photo.java
+++ b/src/main/java/org/example/sqi_images/photo/domain/Photo.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.example.sqi_images.common.domain.BaseEntity;
-import org.example.sqi_images.employee.domain.Employee;
+import org.example.sqi_images.employee.domain.EmployeeDetail;
 
 @Entity
 @Getter
@@ -21,5 +21,9 @@ public class Photo extends BaseEntity {
     private byte[] photoData;
 
     @OneToOne(mappedBy = "photo")
-    private Employee employee;
+    private EmployeeDetail detail;
+
+    public Photo(byte[] photoData) {
+        this.photoData = photoData;
+    }
 }

--- a/src/main/java/org/example/sqi_images/photo/service/PhotoService.java
+++ b/src/main/java/org/example/sqi_images/photo/service/PhotoService.java
@@ -2,7 +2,6 @@ package org.example.sqi_images.photo.service;
 
 import lombok.RequiredArgsConstructor;
 import org.example.sqi_images.common.exception.NotFoundException;
-import org.example.sqi_images.employee.domain.Employee;
 import org.example.sqi_images.photo.dto.response.PhotoDataResponse;
 import org.example.sqi_images.photo.domain.Photo;
 import org.example.sqi_images.photo.domain.repository.PhotoRepository;
@@ -20,12 +19,12 @@ import static org.example.sqi_images.common.exception.type.ErrorType.PHOTO_NOT_F
 public class PhotoService {
 
     private final PhotoRepository photoRepository;
-    @Value("${app.imageUrl}")
-    private String imageUrl;
+    @Value("${app.baseUrl}")
+    private String baseUrl;
 
     @Transactional
-    public Photo saveImage(Employee employee, MultipartFile file) throws IOException {
-        Photo photo = new Photo(file.getBytes(), employee);
+    public Photo saveImage(MultipartFile file) throws IOException {
+        Photo photo = new Photo(file.getBytes());
         return photoRepository.save(photo);
     }
 
@@ -38,6 +37,6 @@ public class PhotoService {
     }
 
     public String generateImageUrl(Long photoId) {
-        return imageUrl + photoId;
+        return baseUrl + "api/images/" + photoId;
     }
 }


### PR DESCRIPTION
## Description
- 프로필 조회 시에만 사용되는 필드 엔티티 분리
- languateType, frameworkType, photo 저장용 EmployeeDetail 엔티티 생성
## Changes
### Domain 생성
- [x] EmployeeDetail
- [x] EmployeeDetailRepository
### 매핑 변경
- [x] Employee
- [x] Photo
- [x] Department
- [x] GlobalFile
### Service
- [x] ProfileService
- [x] EmployeeService
## Additional context

Closes #41 