### PR TITLE
Feature/#65 시스템 관리자 권한과 일반 유저 권한으로 분리

### DIFF
--- a/src/main/java/org/example/sqi_images/auth/authentication/AccessTokenProvider.java
+++ b/src/main/java/org/example/sqi_images/auth/authentication/AccessTokenProvider.java
@@ -4,7 +4,6 @@ import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
-import lombok.extern.slf4j.Slf4j;
 import org.example.sqi_images.common.exception.UnauthorizedException;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -15,9 +14,9 @@ import java.util.Date;
 
 import static org.example.sqi_images.common.exception.type.ErrorType.INVALID_JWT_ERROR;
 
-@Slf4j
 @Component
 public class AccessTokenProvider {
+
     private final SecretKey key; // AccessToken 시크릿 키
     private final long validityInMilliseconds; // AccessToken 유효 시간
 

--- a/src/main/java/org/example/sqi_images/auth/authentication/AuthenticationExtractor.java
+++ b/src/main/java/org/example/sqi_images/auth/authentication/AuthenticationExtractor.java
@@ -7,13 +7,13 @@ import org.example.sqi_images.auth.utils.JwtUtil;
 import org.example.sqi_images.common.exception.UnauthorizedException;
 
 import static org.example.sqi_images.common.constant.Constants.TOKEN_COOKIE_NAME;
-import static org.example.sqi_images.common.exception.type.ErrorType.COOKIE_NOT_FOUND_ERROR;
+import static org.example.sqi_images.common.exception.type.ErrorType.TOKEN_NOT_FOUND_ERROR;
 
 
 public class AuthenticationExtractor {
 
     private AuthenticationExtractor() {
-        throw new UnsupportedOperationException("This is a utility class and cannot be instantiated");
+        throw new UnsupportedOperationException("Utility class");
     }
 
     public static String extract(final HttpServletRequest request) {
@@ -25,6 +25,6 @@ public class AuthenticationExtractor {
                 }
             }
         }
-        throw new UnauthorizedException(COOKIE_NOT_FOUND_ERROR);
+        throw new UnauthorizedException(TOKEN_NOT_FOUND_ERROR);
     }
 }

--- a/src/main/java/org/example/sqi_images/auth/authentication/annotation/Admin.java
+++ b/src/main/java/org/example/sqi_images/auth/authentication/annotation/Admin.java
@@ -1,0 +1,16 @@
+package org.example.sqi_images.auth.authentication.annotation;
+
+import org.example.sqi_images.employee.domain.EmployeeRole;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import static org.example.sqi_images.employee.domain.EmployeeRole.ADMIN;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Admin {
+    EmployeeRole role() default ADMIN;
+}

--- a/src/main/java/org/example/sqi_images/auth/authentication/config/AuthenticationConfig.java
+++ b/src/main/java/org/example/sqi_images/auth/authentication/config/AuthenticationConfig.java
@@ -2,6 +2,7 @@ package org.example.sqi_images.auth.authentication.config;
 
 import lombok.RequiredArgsConstructor;
 import org.example.sqi_images.auth.authentication.argumentresolver.AuthenticatedEmployeeArgumentResolver;
+import org.example.sqi_images.auth.authentication.interceptor.AdminRoleInterceptor;
 import org.example.sqi_images.auth.authentication.interceptor.AuthenticationInterceptor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
@@ -17,11 +18,13 @@ import static org.example.sqi_images.common.constant.Constants.*;
 public class AuthenticationConfig implements WebMvcConfigurer {
 
     private final AuthenticationInterceptor authenticationInterceptor;
+    private final AdminRoleInterceptor adminRoleInterceptor;
     private final AuthenticatedEmployeeArgumentResolver authenticatedEmployeeArgumentResolver;
 
     @Override
     public void addInterceptors(final InterceptorRegistry registry) {
         addAuthenticationInterceptor(registry);
+        addAdminRoleInterceptor(registry);
     }
 
     private void addAuthenticationInterceptor(final InterceptorRegistry registry) {
@@ -30,6 +33,11 @@ public class AuthenticationConfig implements WebMvcConfigurer {
                 .addPathPatterns(ADD_PROFILE_API_PATH)
                 .addPathPatterns(ADD_DRIVE_API_PATH)
                 .excludePathPatterns(EXCLUDE_AUTH_API_PATH);
+    }
+
+    private void addAdminRoleInterceptor(final InterceptorRegistry registry) {
+        registry.addInterceptor(adminRoleInterceptor)
+                .addPathPatterns();
     }
 
     @Override

--- a/src/main/java/org/example/sqi_images/auth/authentication/interceptor/AdminRoleInterceptor.java
+++ b/src/main/java/org/example/sqi_images/auth/authentication/interceptor/AdminRoleInterceptor.java
@@ -1,0 +1,52 @@
+package org.example.sqi_images.auth.authentication.interceptor;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.example.sqi_images.auth.authentication.AuthenticationContext;
+import org.example.sqi_images.auth.authentication.annotation.Admin;
+import org.example.sqi_images.employee.domain.Employee;
+import org.springframework.stereotype.Component;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import java.io.IOException;
+
+import static org.example.sqi_images.employee.domain.EmployeeRole.ADMIN;
+
+@Component
+@RequiredArgsConstructor
+public class AdminRoleInterceptor implements HandlerInterceptor {
+
+    private final AuthenticationContext authenticationContext;
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        if (!(handler instanceof HandlerMethod)) {
+            return true;
+        }
+
+        HandlerMethod handlerMethod = (HandlerMethod) handler;
+        Admin adminAnnotation = handlerMethod.getMethodAnnotation(Admin.class);
+
+        // Admin 어노테이션이 없으면 권한 체크 필요 없음
+        if (adminAnnotation == null) {
+            return true;
+        }
+
+        // Admin 어노테이션이 있는 경우, 관리자 권한 체크
+        return checkAdminRole(response);
+    }
+
+    private boolean checkAdminRole(HttpServletResponse response) throws IOException {
+        Employee employee = authenticationContext.getPrincipal();
+
+        // 관리자 권한이 아닌 경우 처리
+        if (employee.getRole() != ADMIN) {
+            response.sendError(HttpServletResponse.SC_FORBIDDEN, "해당 작업은 관리자 권한이 필요합니다.");
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/main/java/org/example/sqi_images/auth/authentication/interceptor/AuthenticationInterceptor.java
+++ b/src/main/java/org/example/sqi_images/auth/authentication/interceptor/AuthenticationInterceptor.java
@@ -6,12 +6,13 @@ import lombok.RequiredArgsConstructor;
 import org.example.sqi_images.auth.authentication.AccessTokenProvider;
 import org.example.sqi_images.auth.authentication.AuthenticationContext;
 import org.example.sqi_images.auth.authentication.AuthenticationExtractor;
+import org.example.sqi_images.common.exception.UnauthorizedException;
 import org.example.sqi_images.employee.domain.Employee;
 import org.example.sqi_images.employee.service.EmployeeQueryService;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
 
-import java.io.UnsupportedEncodingException;
+import java.io.IOException;
 
 @Component
 @RequiredArgsConstructor
@@ -22,11 +23,19 @@ public class AuthenticationInterceptor implements HandlerInterceptor {
     private final AccessTokenProvider accessTokenProvider;
 
     @Override
-    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws UnsupportedEncodingException {
-        String accessToken = AuthenticationExtractor.extract(request);
-        Long employeeId = Long.valueOf(accessTokenProvider.getPayload(accessToken));
-        Employee employee = employeeQueryService.findExistingEmployee(employeeId);
-        authenticationContext.setPrincipal(employee);
-        return true;
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws IOException {
+        try {
+            // JWT 토큰 추출 및 유효성 검사
+            String accessToken = AuthenticationExtractor.extract(request);
+            Long employeeId = Long.valueOf(accessTokenProvider.getPayload(accessToken));
+
+            // employeeId로 사용자 정보 조회 후 컨텍스트에 저장
+            Employee employee = employeeQueryService.findExistingEmployee(employeeId);
+            authenticationContext.setPrincipal(employee);
+            return true;
+        } catch (UnauthorizedException e) {
+            response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "유효하지 않은 토큰입니다.");
+            return false;
+        }
     }
 }

--- a/src/main/java/org/example/sqi_images/auth/service/AuthService.java
+++ b/src/main/java/org/example/sqi_images/auth/service/AuthService.java
@@ -14,6 +14,7 @@ import org.springframework.stereotype.Service;
 
 import static org.example.sqi_images.common.constant.Constants.SQISOFT_EMAIL;
 import static org.example.sqi_images.common.exception.type.ErrorType.*;
+import static org.example.sqi_images.employee.domain.EmployeeRole.USER;
 
 @Service
 @RequiredArgsConstructor
@@ -34,7 +35,7 @@ public class AuthService {
         String plainPassword = registerDto.password();
         String encryptedPassword = passwordHashEncryption.encrypt(plainPassword);
 
-        Employee newEmployee = new Employee(email, encryptedPassword, name);
+        Employee newEmployee = new Employee(email, encryptedPassword, name, USER);
         employeeRepository.save(newEmployee);
     }
 
@@ -46,8 +47,6 @@ public class AuthService {
         String accessToken = accessTokenProvider.createToken(String.valueOf(employee.getId()));
         return new TokenDto(accessToken);
     }
-
-
 
     public void validateIsPasswordMatches(String requestedPassword, String userPassword) {
         if (!passwordHashEncryption.matches(requestedPassword, userPassword)) {

--- a/src/main/java/org/example/sqi_images/auth/utils/PasswordHashEncryption.java
+++ b/src/main/java/org/example/sqi_images/auth/utils/PasswordHashEncryption.java
@@ -10,9 +10,11 @@ import java.security.spec.InvalidKeySpecException;
 import java.security.spec.KeySpec;
 import java.util.Base64;
 
+import static org.example.sqi_images.common.constant.Constants.PBKDF2_WITH_SHA1;
+
 @Component
 public class PasswordHashEncryption {
-    private static final String PBKDF2_WITH_SHA1 = "PBKDF2WithHmacSHA1";
+
     private final String salt;
     private final int iterationCount;
     private final int keyLength;

--- a/src/main/java/org/example/sqi_images/common/constant/Constants.java
+++ b/src/main/java/org/example/sqi_images/common/constant/Constants.java
@@ -15,6 +15,7 @@ public class Constants {
     public static final String ADD_AUTH_API_PATH = "/api/auth/logout";
     public static final String ADD_PROFILE_API_PATH = "/api/profiles/**";
     public static final List<String> EXCLUDE_AUTH_API_PATH = List.of("/api/auth/login", "/api/auth/sign-up");
+    public static final String PBKDF2_WITH_SHA1 = "PBKDF2WithHmacSHA1";
 
     // Drive
     public static final String ADD_DRIVE_API_PATH = "/api/drives/**";

--- a/src/main/java/org/example/sqi_images/common/exception/type/ErrorType.java
+++ b/src/main/java/org/example/sqi_images/common/exception/type/ErrorType.java
@@ -15,7 +15,7 @@ public enum ErrorType {
     NOT_AUTHENTICATED_ERROR(40100, "인증되지 않았습니다."),
     INVALID_CREDENTIALS_ERROR(40101, "아이디나 비밀번호가 일치하지 않습니다."),
     JWT_NOT_FOUND_ERROR(40102, "인증 정보가 없습니다."),
-    COOKIE_NOT_FOUND_ERROR(40103, "쿠키 정보가 없습니다."),
+    TOKEN_NOT_FOUND_ERROR(40103, "토큰 정보가 없습니다."),
     INVALID_JWT_ERROR(40104, "인증 정보가 유효하지 않습니다."),
     TOKEN_EXPIRED_ERROR(40105, "인증에 필요한 토큰이 만료되었습니다."),
 

--- a/src/main/java/org/example/sqi_images/drive/aop/annotation/CheckDriveAccess.java
+++ b/src/main/java/org/example/sqi_images/drive/aop/annotation/CheckDriveAccess.java
@@ -10,5 +10,5 @@ import java.lang.annotation.Target;
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface CheckDriveAccess {
-    DriveAccessType[] accessType() default DriveAccessType.USER;
+    DriveAccessType[] accessType() default DriveAccessType.DRIVE_USER;
 }

--- a/src/main/java/org/example/sqi_images/drive/controller/DriveController.java
+++ b/src/main/java/org/example/sqi_images/drive/controller/DriveController.java
@@ -22,8 +22,8 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
 
-import static org.example.sqi_images.drive.domain.DriveAccessType.ADMIN;
-import static org.example.sqi_images.drive.domain.DriveAccessType.USER;
+import static org.example.sqi_images.drive.domain.DriveAccessType.DRIVE_ADMIN;
+import static org.example.sqi_images.drive.domain.DriveAccessType.DRIVE_USER;
 import static org.example.sqi_images.file.util.FileUtil.createFileDownloadHeaders;
 
 @RestController
@@ -43,7 +43,7 @@ public class DriveController {
     }
 
     @PostMapping("/{driveId}/files")
-    @CheckDriveAccess(accessType = {ADMIN, USER})
+    @CheckDriveAccess(accessType = {DRIVE_ADMIN, DRIVE_USER})
     public ResponseEntity<String> uploadFileToDrive(
             @PathVariable Long driveId,
             @AuthEmployee Employee employee,
@@ -53,7 +53,7 @@ public class DriveController {
     }
 
     @PostMapping("/{driveId}/assign-roles")
-    @CheckDriveAccess(accessType = {ADMIN})
+    @CheckDriveAccess(accessType = {DRIVE_ADMIN})
     public ResponseEntity<String> assignRoles(
             @PathVariable Long driveId,
             @AuthEmployee Employee employee,
@@ -63,7 +63,7 @@ public class DriveController {
     }
 
     @GetMapping("/{driveId}/files/{fileId}")
-    @CheckDriveAccess(accessType = {ADMIN, USER})
+    @CheckDriveAccess(accessType = {DRIVE_ADMIN, DRIVE_USER})
     public ResponseEntity<ByteArrayResource> downloadDriveFile(
             @PathVariable Long driveId,
             @PathVariable Long fileId) {
@@ -77,7 +77,7 @@ public class DriveController {
     }
 
     @GetMapping("/{driveId}/files")
-    @CheckDriveAccess(accessType = {ADMIN, USER})
+    @CheckDriveAccess(accessType = {DRIVE_ADMIN, DRIVE_USER})
     public ResponseEntity<PageResultDto<FileInfoResponseDto, FileInfo>> getAllDriveFiles(
             @PathVariable Long driveId,
             @RequestParam(defaultValue = "1") int page) {
@@ -86,7 +86,7 @@ public class DriveController {
     }
 
     @GetMapping("/{driveId}/trash-files")
-    @CheckDriveAccess(accessType = {ADMIN, USER})
+    @CheckDriveAccess(accessType = {DRIVE_ADMIN, DRIVE_USER})
     public ResponseEntity<PageResultDto<FileInfoResponseDto, FileInfo>> getAllDriveTrashFiles(
             @PathVariable Long driveId,
             @RequestParam(defaultValue = "1") int page) {
@@ -95,7 +95,7 @@ public class DriveController {
     }
 
     @PostMapping("/{driveId}/files/{fileId}")
-    @CheckDriveAccess(accessType = {USER, ADMIN})
+    @CheckDriveAccess(accessType = {DRIVE_USER, DRIVE_ADMIN})
     public ResponseEntity<String> setTrashDriveFile(
             @PathVariable Long driveId,
             @AuthEmployee Employee employee,
@@ -105,7 +105,7 @@ public class DriveController {
     }
 
     @PatchMapping("/{driveId}/trash-files/{fileId}")
-    @CheckDriveAccess(accessType = {ADMIN, USER})
+    @CheckDriveAccess(accessType = {DRIVE_ADMIN, DRIVE_USER})
     public ResponseEntity<String> restoreTrashDriveFile(
             @PathVariable Long driveId,
             @AuthEmployee Employee employee,
@@ -115,7 +115,7 @@ public class DriveController {
     }
 
     @DeleteMapping("/{driveId}/trash-files/{fileId}")
-    @CheckDriveAccess(accessType = {ADMIN, USER})
+    @CheckDriveAccess(accessType = {DRIVE_ADMIN, DRIVE_USER})
     public ResponseEntity<String> deleteDriveFile(
             @PathVariable Long driveId,
             @AuthEmployee Employee employee,
@@ -125,7 +125,7 @@ public class DriveController {
     }
 
     @DeleteMapping("/{driveId}")
-    @CheckDriveAccess(accessType = {ADMIN})
+    @CheckDriveAccess(accessType = {DRIVE_ADMIN})
     public ResponseEntity<String> deleteDrive(@PathVariable Long driveId) {
         driveService.deleteDrive(driveId);
         return ResponseEntity.ok("공유 드라이브가 성공적으로 삭제되었습니다.");

--- a/src/main/java/org/example/sqi_images/drive/domain/DriveAccessType.java
+++ b/src/main/java/org/example/sqi_images/drive/domain/DriveAccessType.java
@@ -1,6 +1,6 @@
 package org.example.sqi_images.drive.domain;
 
 public enum DriveAccessType {
-    ADMIN,
-    USER
+    DRIVE_ADMIN,
+    DRIVE_USER
 }

--- a/src/main/java/org/example/sqi_images/drive/service/DriveService.java
+++ b/src/main/java/org/example/sqi_images/drive/service/DriveService.java
@@ -26,8 +26,8 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static org.example.sqi_images.common.exception.type.ErrorType.*;
-import static org.example.sqi_images.drive.domain.DriveAccessType.ADMIN;
-import static org.example.sqi_images.drive.domain.DriveAccessType.USER;
+import static org.example.sqi_images.drive.domain.DriveAccessType.DRIVE_ADMIN;
+import static org.example.sqi_images.drive.domain.DriveAccessType.DRIVE_USER;
 
 @Service
 @RequiredArgsConstructor
@@ -46,7 +46,7 @@ public class DriveService {
         Drive drive = new Drive(createDriveDto.driveName());
         driveRepository.save(drive);
 
-        DriveEmployee driveEmployee = new DriveEmployee(employee, drive, ADMIN, employee);
+        DriveEmployee driveEmployee = new DriveEmployee(employee, drive, DRIVE_ADMIN, employee);
         driveEmployeeRepository.save(driveEmployee);
     }
 
@@ -166,10 +166,10 @@ public class DriveService {
     // ADMIN 권한 보유 or USER 권한자면서 파일 업로더 검증
     private void validateAccessOrUploader(Long driveId, Long employeeId, FileInfo fileInfo) {
         DriveEmployee driveEmployee = driveQueryService.findExistingAccess(driveId, employeeId);
-        boolean isAdmin = driveEmployee.getRole() == ADMIN;
+        boolean isAdmin = driveEmployee.getRole() == DRIVE_ADMIN;
         boolean isUploader = fileInfo.getEmployee().getId().equals(employeeId);
 
-        if (!(isAdmin || (driveEmployee.getRole() == USER && isUploader))) {
+        if (!(isAdmin || (driveEmployee.getRole() == DRIVE_USER && isUploader))) {
             throw new ForbiddenException(NO_ADMIN_ACCESS_ERROR);
         }
     }

--- a/src/main/java/org/example/sqi_images/employee/domain/Employee.java
+++ b/src/main/java/org/example/sqi_images/employee/domain/Employee.java
@@ -26,6 +26,10 @@ public class Employee extends BaseEntity {
     @Column(nullable = false, unique = true)
     private String name;
 
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private EmployeeRole role;
+
     @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     @JoinColumn(name = "detail_id")
     private EmployeeDetail detail;
@@ -37,10 +41,11 @@ public class Employee extends BaseEntity {
     @JoinColumn(name = "part_id")
     private Part part;
 
-    public Employee(String email, String password, String name) {
+    public Employee(String email, String password, String name, EmployeeRole role) {
         this.email = email;
         this.password = password;
         this.name = name;
+        this.role = role;
     }
 
     public void updatePart(Part part) {

--- a/src/main/java/org/example/sqi_images/employee/domain/EmployeeRole.java
+++ b/src/main/java/org/example/sqi_images/employee/domain/EmployeeRole.java
@@ -1,0 +1,6 @@
+package org.example.sqi_images.employee.domain;
+
+public enum EmployeeRole  {
+    ADMIN,
+    USER
+}


### PR DESCRIPTION
## Description
- 시스템 관리자 권한과 일반 유저 권한으로 분리
- 시스템 ADMIN 권한자만 이용할 수 있는 기능 추가
- Admin 확인용 커스텀 어노테이션, 인터셉터 추가
- 회원가입 시 모든 사용자는 USER 권한 지급
## Changes
### Domain
- [x] Employee
- [x] EmployeeRole
### Annotation
- [x] Admin
### Interceptor
- [x] AdminRoleInterceptor
### Config
- [x] AuthenticationConfig
## Additional context

Closes #65 