### PR TITLE
Feature/#70 공유 드라이브 전체 조회 기능 추가

### DIFF
--- a/src/main/java/org/example/sqi_images/common/dto/page/request/PageRequestDto.java
+++ b/src/main/java/org/example/sqi_images/common/dto/page/request/PageRequestDto.java
@@ -8,15 +8,21 @@ import org.springframework.data.domain.Sort;
 public record PageRequestDto(int page) {
 
     private static final int PAGE_SIZE = 10;
-    private static final String SORT_BY = "createdAt";
-    private static final Sort.Direction SORT_DIRECTION = Sort.Direction.DESC;
+    private static final String SORT_BY_CREATED_AT = "createdAt";
+    private static final String SORT_BY_NAME = "name";
+    private static final Sort.Direction SORT_DESC = Sort.Direction.DESC;
+    private static final Sort.Direction SORT_ASC = Sort.Direction.ASC;
 
 
     public PageRequestDto(int page) {
         this.page = Math.max(page - 1, 0);
     }
 
-    public Pageable toPageable() {
-        return PageRequest.of(page, PAGE_SIZE, Sort.by(SORT_DIRECTION, SORT_BY));
+    public Pageable toCurrentPageable() {
+        return PageRequest.of(page, PAGE_SIZE, Sort.by(SORT_DESC, SORT_BY_CREATED_AT));
+    }
+
+    public Pageable toNameAscPageable() {
+        return PageRequest.of(page, PAGE_SIZE, Sort.by(SORT_ASC, SORT_BY_NAME));
     }
 }

--- a/src/main/java/org/example/sqi_images/drive/controller/DriveController.java
+++ b/src/main/java/org/example/sqi_images/drive/controller/DriveController.java
@@ -7,6 +7,7 @@ import org.example.sqi_images.common.dto.page.response.PageResultDto;
 import org.example.sqi_images.drive.aop.annotation.CheckDriveAccess;
 import org.example.sqi_images.drive.dto.request.AssignRoleRequestList;
 import org.example.sqi_images.drive.dto.request.CreateDriveDto;
+import org.example.sqi_images.drive.dto.response.DriveInfo;
 import org.example.sqi_images.drive.service.DriveQueryService;
 import org.example.sqi_images.drive.service.DriveService;
 import org.example.sqi_images.employee.domain.Employee;
@@ -21,6 +22,7 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.util.List;
 
 import static org.example.sqi_images.drive.domain.DriveAccessType.DRIVE_ADMIN;
 import static org.example.sqi_images.drive.domain.DriveAccessType.DRIVE_USER;
@@ -40,6 +42,12 @@ public class DriveController {
             @RequestBody @Valid CreateDriveDto createDriveDto) {
         driveService.createDrive(employee, createDriveDto);
         return ResponseEntity.ok("공유 드라이브가 성공적으로 생성되었습니다.");
+    }
+
+    @GetMapping
+    public ResponseEntity<List<DriveInfo>> getAllDrives() {
+        List<DriveInfo> allDrives = driveQueryService.getAllDrives();
+        return ResponseEntity.ok(allDrives);
     }
 
     @PostMapping("/{driveId}/files")

--- a/src/main/java/org/example/sqi_images/drive/controller/DriveController.java
+++ b/src/main/java/org/example/sqi_images/drive/controller/DriveController.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import org.example.sqi_images.auth.authentication.annotation.AuthEmployee;
 import org.example.sqi_images.common.dto.page.response.PageResultDto;
 import org.example.sqi_images.drive.aop.annotation.CheckDriveAccess;
+import org.example.sqi_images.drive.domain.Drive;
 import org.example.sqi_images.drive.dto.request.AssignRoleRequestList;
 import org.example.sqi_images.drive.dto.request.CreateDriveDto;
 import org.example.sqi_images.drive.dto.response.DriveInfo;
@@ -22,7 +23,6 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
-import java.util.List;
 
 import static org.example.sqi_images.drive.domain.DriveAccessType.DRIVE_ADMIN;
 import static org.example.sqi_images.drive.domain.DriveAccessType.DRIVE_USER;
@@ -45,9 +45,9 @@ public class DriveController {
     }
 
     @GetMapping
-    public ResponseEntity<List<DriveInfo>> getAllDrives() {
-        List<DriveInfo> allDrives = driveQueryService.getAllDrives();
-        return ResponseEntity.ok(allDrives);
+    public ResponseEntity<PageResultDto<DriveInfo, Drive>> getAllDrives(@RequestParam(defaultValue = "1") int page) {
+        PageResultDto<DriveInfo, Drive> result = driveQueryService.getAllDrives(page);
+        return ResponseEntity.ok(result);
     }
 
     @PostMapping("/{driveId}/files")

--- a/src/main/java/org/example/sqi_images/drive/domain/Drive.java
+++ b/src/main/java/org/example/sqi_images/drive/domain/Drive.java
@@ -19,7 +19,7 @@ import java.util.List;
 public class Drive extends BaseEntity {
 
     @Column(nullable = false)
-    private String driveName;
+    private String name;
 
     @OneToMany(mappedBy = "drive", cascade = CascadeType.REMOVE, orphanRemoval = true)
     private List<DriveEmployee> driveEmployees;
@@ -27,7 +27,7 @@ public class Drive extends BaseEntity {
     @OneToMany(mappedBy = "drive", cascade = CascadeType.REMOVE, orphanRemoval = true)
     private List<FileInfo> fileInfos;
 
-    public Drive(String driveName) {
-        this.driveName = driveName;
+    public Drive(String name) {
+        this.name = name;
     }
 }

--- a/src/main/java/org/example/sqi_images/drive/domain/repository/DriveRepository.java
+++ b/src/main/java/org/example/sqi_images/drive/domain/repository/DriveRepository.java
@@ -1,8 +1,17 @@
 package org.example.sqi_images.drive.domain.repository;
 
 import org.example.sqi_images.drive.domain.Drive;
+import org.example.sqi_images.drive.dto.response.DriveInfo;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
 
 public interface DriveRepository extends JpaRepository<Drive, Long> {
     boolean existsById(Long driveId);
+
+    @Query("SELECT new org.example.sqi_images.drive.dto.response.DriveInfo(d.id, d.driveName, COUNT(de)) " +
+            "FROM Drive d LEFT JOIN d.driveEmployees de " +
+            "GROUP BY d.id, d.driveName")
+    List<DriveInfo> findAllDrivesWithEmployeeCount();
 }

--- a/src/main/java/org/example/sqi_images/drive/domain/repository/DriveRepository.java
+++ b/src/main/java/org/example/sqi_images/drive/domain/repository/DriveRepository.java
@@ -1,17 +1,8 @@
 package org.example.sqi_images.drive.domain.repository;
 
 import org.example.sqi_images.drive.domain.Drive;
-import org.example.sqi_images.drive.dto.response.DriveInfo;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-
-import java.util.List;
 
 public interface DriveRepository extends JpaRepository<Drive, Long> {
     boolean existsById(Long driveId);
-
-    @Query("SELECT new org.example.sqi_images.drive.dto.response.DriveInfo(d.id, d.driveName, COUNT(de)) " +
-            "FROM Drive d LEFT JOIN d.driveEmployees de " +
-            "GROUP BY d.id, d.driveName")
-    List<DriveInfo> findAllDrivesWithEmployeeCount();
 }

--- a/src/main/java/org/example/sqi_images/drive/dto/response/DriveInfo.java
+++ b/src/main/java/org/example/sqi_images/drive/dto/response/DriveInfo.java
@@ -1,0 +1,8 @@
+package org.example.sqi_images.drive.dto.response;
+
+public record DriveInfo(
+        Long driveId,
+        String driveName,
+        Long memberCount
+) {
+}

--- a/src/main/java/org/example/sqi_images/drive/dto/response/DriveInfo.java
+++ b/src/main/java/org/example/sqi_images/drive/dto/response/DriveInfo.java
@@ -1,8 +1,15 @@
 package org.example.sqi_images.drive.dto.response;
 
+import org.example.sqi_images.drive.domain.Drive;
+
 public record DriveInfo(
         Long driveId,
-        String driveName,
-        Long memberCount
+        String driveName
 ) {
+    public static DriveInfo from(Drive drive) {
+        return new DriveInfo(
+                drive.getId(),
+                drive.getName()
+        );
+    }
 }

--- a/src/main/java/org/example/sqi_images/drive/service/DriveQueryService.java
+++ b/src/main/java/org/example/sqi_images/drive/service/DriveQueryService.java
@@ -18,8 +18,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
-
 import static org.example.sqi_images.common.exception.type.ErrorType.*;
 
 @Service
@@ -34,8 +32,12 @@ public class DriveQueryService {
     /**
      * 공유 드라이브 전체 조회
      */
-    public List<DriveInfo> getAllDrives() {
-        return driveRepository.findAllDrivesWithEmployeeCount();
+    public PageResultDto<DriveInfo, Drive> getAllDrives(int page) {
+        PageRequestDto pageRequestDto = new PageRequestDto(page);
+        Pageable pageable = pageRequestDto.toNameAscPageable();
+        Page<Drive> result = driveRepository.findAll(pageable);
+
+        return new PageResultDto<>(result, DriveInfo::from);
     }
 
     /**
@@ -43,7 +45,7 @@ public class DriveQueryService {
      */
     public PageResultDto<FileInfoResponseDto, FileInfo> getAllDriveFiles(Long driveId, int page) {
         PageRequestDto pageRequestDto = new PageRequestDto(page);
-        Pageable pageable = pageRequestDto.toPageable();
+        Pageable pageable = pageRequestDto.toCurrentPageable();
         Page<FileInfo> result = fileInfoRepository.findByDriveIdWithFetchJoin(driveId, pageable);
 
         return new PageResultDto<>(result, FileInfoResponseDto::notDeletedFilesFrom);
@@ -54,7 +56,7 @@ public class DriveQueryService {
      */
     public PageResultDto<FileInfoResponseDto, FileInfo> getAllTrashFiles(Long driveId, int page) {
         PageRequestDto pageRequestDto = new PageRequestDto(page);
-        Pageable pageable = pageRequestDto.toPageable();
+        Pageable pageable = pageRequestDto.toCurrentPageable();
         Page<FileInfo> result = fileInfoRepository.findByDriveIdAndIsDeletedTrue(driveId, pageable);
 
         return new PageResultDto<>(result, FileInfoResponseDto::deletedFilesFrom);

--- a/src/main/java/org/example/sqi_images/drive/service/DriveQueryService.java
+++ b/src/main/java/org/example/sqi_images/drive/service/DriveQueryService.java
@@ -9,6 +9,7 @@ import org.example.sqi_images.drive.domain.Drive;
 import org.example.sqi_images.drive.domain.DriveEmployee;
 import org.example.sqi_images.drive.domain.repository.DriveEmployeeRepository;
 import org.example.sqi_images.drive.domain.repository.DriveRepository;
+import org.example.sqi_images.drive.dto.response.DriveInfo;
 import org.example.sqi_images.file.domain.FileInfo;
 import org.example.sqi_images.file.domain.repository.FileInfoRepository;
 import org.example.sqi_images.file.dto.response.FileInfoResponseDto;
@@ -16,6 +17,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 import static org.example.sqi_images.common.exception.type.ErrorType.*;
 
@@ -27,6 +30,13 @@ public class DriveQueryService {
     private final FileInfoRepository fileInfoRepository;
     private final DriveRepository driveRepository;
     private final DriveEmployeeRepository driveEmployeeRepository;
+
+    /**
+     * 공유 드라이브 전체 조회
+     */
+    public List<DriveInfo> getAllDrives() {
+        return driveRepository.findAllDrivesWithEmployeeCount();
+    }
 
     /**
      * 공유 드라이브 파일 전체 조회

--- a/src/main/java/org/example/sqi_images/employee/domain/repository/EmployeeRepository.java
+++ b/src/main/java/org/example/sqi_images/employee/domain/repository/EmployeeRepository.java
@@ -19,10 +19,6 @@ public interface EmployeeRepository extends JpaRepository<Employee, Long> {
     boolean existsByEmail(String email);
 
     @Query("SELECT e FROM Employee e " +
-            "JOIN FETCH e.detail")
-    List<Employee> findAllWithDetail();
-
-    @Query("SELECT e FROM Employee e " +
             "JOIN FETCH e.detail " +
             "WHERE e.id = :id")
     Optional<Employee> findByIdWithDetail(@Param("id") Long id);


### PR DESCRIPTION
## Description
- 공유 드라이브 전체 조회 기능 추가
- 현재 존재하는 공유 드라이브 리스트 조회 기능, 페이징 처리
- 드라이브ID, 드라이브 이름, 멤버 수(엑세스 소유자 수) 리스트로 반환
## Changes
### Controller
- [ ] DriveController
### Service
- [ ] DriveService
### Dto
- [ ] 
## Additional context

Closes #70 